### PR TITLE
[#1302] Tracking Aura Adjustment

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -3731,6 +3731,13 @@ bool Unit::RemoveNoStackAurasDueToAura(Aura* Aur)
     uint32 spellId = Aur->GetId();
     uint32 effIndex = Aur->GetEffIndex();
 
+    // If a tracking aura is being applied, remove other instances of tracking auras.
+    if (Aur->GetAuraType() == SPELL_AURA_TRACK_CREATURES || Aur->GetAuraType() == SPELL_AURA_TRACK_RESOURCES)
+    {
+        RemoveAurasByType(SPELL_AURA_TRACK_CREATURES, GetGUID(),Aur);
+        RemoveAurasByType(SPELL_AURA_TRACK_RESOURCES, GetGUID(),Aur);
+    }
+
     AuraMap::iterator i, next;
     for (i = m_Auras.begin(); i != m_Auras.end(); i = next)
     {


### PR DESCRIPTION
Selecting a tracking option will now purge all older tracking auras, allowing the user to switch between tracking without having to cancel tracking all the way back to "Track None".

Brought up in #1302.
