### PR TITLE
[#1321] Restricting the "Made By" tag.

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -3076,7 +3076,7 @@ void Spell::DoCreateItem(uint32 /*i*/, uint32 itemtype)
         }
 
         // set the "Crafted by ..." property of the item
-        if (pItem->GetProto()->Class != ITEM_CLASS_CONSUMABLE && pItem->GetProto()->Class != ITEM_CLASS_QUEST)
+        if (m_spellInfo->Category != SPELL_CATEGORY_UNCATEGORIZED && pItem->GetProto()->Class != ITEM_CLASS_CONSUMABLE && pItem->GetProto()->Class != ITEM_CLASS_QUEST)
             pItem->SetUInt32Value(ITEM_FIELD_CREATOR, player->GetGUIDLow());
 
         // send info to the client


### PR DESCRIPTION
I think that too many items are being granted the "Made By" tag. This change should make all non-profession items (e.g. Motes, Apexis items, Hearthstones) avoid the Made By tag (in addition to the consumables and quest items already being restricted). Brought up in issue #1321.
