### PR TITLE
Custodian of Time (creature 20129) fixes (quest 10277)

### DIFF
--- a/sql/updates/world/2016_04_27_custodian_of_time_fix.sql
+++ b/sql/updates/world/2016_04_27_custodian_of_time_fix.sql
@@ -1,0 +1,7 @@
+-- Change Custodian of Time (20129) emotes to Say instead of Boss Emote
+UPDATE script_texts SET type=4 WHERE entry BETWEEN -1000230 AND -1000217;
+
+-- Add CONDITION_AURA condition to spell 34877 to prevent Custodian of Time (20129) being resummoned while having the debuff
+DELETE FROM conditions WHERE SourceEntry=34877;
+INSERT INTO conditions (SourceTypeOrReferenceId, SourceEntry, ConditionTypeOrReference, ConditionValue1, ConditionValue2, ConditionValue3, NegativeCondition, Comment) VALUES (17, 34877, 1, 34877, 1, 1, 1, "Custodian of Time summon");
+

--- a/src/scripts/Kalimdor/tanaris.cpp
+++ b/src/scripts/Kalimdor/tanaris.cpp
@@ -164,7 +164,16 @@ enum eCustodian
 
 struct npc_custodian_of_timeAI : public npc_escortAI
 {
-    npc_custodian_of_timeAI(Creature* c) : npc_escortAI(c) {}
+    npc_custodian_of_timeAI(Creature* c) : npc_escortAI(c) 
+    {
+        TempSummon* summon = c->ToTempSummon();
+        if (summon)
+        {
+            Unit* summoner = summon->GetSummoner();
+            if (summoner && summoner->GetTypeId() == TYPEID_PLAYER)
+                Start(false, false, summoner->GetGUID());
+        }
+    }
 
     void WaypointReached(uint32 i)
     {
@@ -234,21 +243,7 @@ struct npc_custodian_of_timeAI : public npc_escortAI
         }
     }
 
-    void MoveInLineOfSight(Unit* who)
-    {
-        if (HasEscortState(STATE_ESCORT_ESCORTING))
-            return;
-
-        if (who->GetTypeId() == TYPEID_PLAYER)
-        {
-            if (who->HasAura(34877, 1) && CAST_PLR(who)->GetQuestStatus(10277) == QUEST_STATUS_INCOMPLETE)
-            {
-                float Radius = 10.0f;
-                if (me->IsWithinDistInMap(who, Radius))
-                    Start(false, false, who->GetGUID());
-            }
-        }
-    }
+    void MoveInLineOfSight(Unit* who) {}
 
     void EnterCombat(Unit* /*who*/) {}
     void Reset() { }


### PR DESCRIPTION
On this [quest ](http://db.hellground.net/?quest=10277) an NPC is summoned that escorts you around and tells you about the caverns of time. You receive a 15 minute debuff (id 34877) to prevent abandoning and retaking the quest to summon more copies of the NPC, however this is not working in the current version and you can summon as many as you want. Also the messages you get from the NPC are currently boss emotes, they should be whispers. So this PR includes these fixes:
- Emotes from Custodian of Time changed from type 3 (Boss Emotes) to type 0 (Whispers).
- Added a condition to the db that prevents the summoning spell (id 34877) from casting if the target has aura 34877 already.
- Modified the way that the escort AI acquires its player owner. Right now it is done by choosing the first player that has the quest accepted but not completed within a 10 yard range. If multiple players stand at the quest giver it would pick any one of them (unless I am misunderstanding how the MoveInLineOfSight function works). My method is to find the Unit that summoned the NPC and start the escort process for this player, which should be more reliable.
