### PR TITLE
[Spells]: Don't interrupt channeled spells at movement with SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING attribute

### DIFF
--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -2268,7 +2268,7 @@ void Spell::prepare(SpellCastTargets* targets, Aura* triggeredByAura)
 
     // don't allow channeled spells / spells with cast time to be casted while moving
     // (even if they are interrupted on moving, spells with almost immediate effect get to have their effect processed before movement interrupter kicks in)
-    if (((IsChanneledSpell(m_spellInfo) && !(m_spellInfo->Attributes & SPELL_ATTR5_CAN_CHANNEL_WHILE_MOVING)) || m_casttime) && m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->isMoving() && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT)
+    if (((IsChanneledSpell(m_spellInfo) && !(m_spellInfo->Attributes & SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING)) || m_casttime) && m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->isMoving() && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT)
     {
         SendCastResult(SPELL_FAILED_MOVING);
         finish(false);
@@ -2563,7 +2563,7 @@ void Spell::handle_immediate()
         }
 
         // Interrupt movement at channeled spells for creature case
-        if (m_caster->GetTypeId() == TYPEID_UNIT && m_caster->isMoving() && !(m_spellInfo->Attributes & SPELL_ATTR5_CAN_CHANNEL_WHILE_MOVING))
+        if (m_caster->GetTypeId() == TYPEID_UNIT && m_caster->isMoving() && !(m_spellInfo->Attributes & SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING))
             m_caster->StopMoving();
     }
 

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -2268,7 +2268,7 @@ void Spell::prepare(SpellCastTargets* targets, Aura* triggeredByAura)
 
     // don't allow channeled spells / spells with cast time to be casted while moving
     // (even if they are interrupted on moving, spells with almost immediate effect get to have their effect processed before movement interrupter kicks in)
-    if ((IsChanneledSpell(m_spellInfo) || m_casttime) && m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->isMoving() && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT)
+    if (((IsChanneledSpell(m_spellInfo) && !(m_spellInfo->Attributes & SPELL_ATTR5_CAN_CHANNEL_WHILE_MOVING)) || m_casttime) && m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->isMoving() && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT)
     {
         SendCastResult(SPELL_FAILED_MOVING);
         finish(false);
@@ -2561,6 +2561,10 @@ void Spell::handle_immediate()
             m_caster->AddInterruptMask(m_spellInfo->ChannelInterruptFlags);
             SendChannelStart(duration);
         }
+
+        // Interrupt movement at channeled spells for creature case
+        if (m_caster->GetTypeId() == TYPEID_UNIT && m_caster->isMoving() && !(m_spellInfo->Attributes & SPELL_ATTR5_CAN_CHANNEL_WHILE_MOVING))
+            m_caster->StopMoving();
     }
 
     // process immediate effects (items, ground, etc.) also initialize some variables


### PR DESCRIPTION
Fixes: #1171
