### PR TITLE
Old hillsbrad start fixes

### DIFF
--- a/src/scripts/Kalimdor/CavernsOfTime/old_hillsbrad/boss_leutenant_drake.cpp
+++ b/src/scripts/Kalimdor/CavernsOfTime/old_hillsbrad/boss_leutenant_drake.cpp
@@ -46,7 +46,7 @@ bool GOHello_go_barrel_old_hillsbrad(Player *player, GameObject* go)
 
     go->UseDoorOrButton(1800);
 
-    return false;
+    return true;
 }
 
 /*######

--- a/src/scripts/Kalimdor/CavernsOfTime/old_hillsbrad/instance_old_hillsbrad.cpp
+++ b/src/scripts/Kalimdor/CavernsOfTime/old_hillsbrad/instance_old_hillsbrad.cpp
@@ -178,9 +178,9 @@ struct instance_old_hillsbrad : public ScriptedInstance
         }
     }
 
-    void OnObjectCreate(GameObject* go)
+    void OnGameObjectCreate(GameObject* go, bool add) override
     {
-        if (go->GetEntry() == GO_ROARING_FLAME)
+        if (add && go->GetEntry() == GO_ROARING_FLAME)
         {
             RoaringFlamesList.push_back(go);
         }
@@ -219,32 +219,33 @@ struct instance_old_hillsbrad : public ScriptedInstance
 
                         Encounter[0] = DONE;
                         Position OrcLocPos;
+                        
+                        // move the orcs outside the houses
+                        float x, y, z;
+                        for (std::list<uint64>::iterator it = RightPrisonersList.begin(); it != RightPrisonersList.end(); ++it)
+                        {
+                            if (Creature* Orc = instance->GetCreature(*it))
+                            {
+                                OrcLocPos.Relocate(OrcLoc[0][0], OrcLoc[0][1], OrcLoc[0][2]);
+                                Orc->GetRandomPoint(OrcLocPos, 10.0f, x, y, z);
+                                Orc->SetWalk(false);
+                                Orc->GetMotionMaster()->MovePoint(0, x, y, z);
+                            }
+                        }
+
+                        for (std::list<uint64>::iterator il = LeftPrisonersList.begin(); il != LeftPrisonersList.end(); ++il)
+                        {
+                            if (Creature* Orc = instance->GetCreature(*il))
+                            {
+                                OrcLocPos.Relocate(OrcLoc[1][0], OrcLoc[1][1], OrcLoc[1][2]);
+                                Orc->GetRandomPoint(OrcLocPos, 10.0f, x, y, z);
+                                Orc->SetWalk(false);
+                                Orc->GetMotionMaster()->MovePoint(0, x, y, z);
+                            }
+                        }
 
                         for (std::list<GameObject*>::iterator itr = RoaringFlamesList.begin(); itr != RoaringFlamesList.end(); ++itr)
                         {
-                            // move the orcs outside the houses
-                            float x, y, z;
-                            for (std::list<uint64>::iterator it = RightPrisonersList.begin(); it != RightPrisonersList.end(); ++it)
-                            {
-                                if (Creature* Orc = instance->GetCreature(*it))
-                                {
-                                    OrcLocPos.Relocate(OrcLoc[0][0], OrcLoc[0][1], OrcLoc[0][2]);
-                                    Orc->GetRandomPoint(OrcLocPos, 10.0f, x, y, z);
-                                    Orc->SetWalk(false);
-                                    Orc->GetMotionMaster()->MovePoint(0, x, y, z);
-                                }
-                            }
-
-                            for (std::list<uint64>::iterator il = LeftPrisonersList.begin(); il != LeftPrisonersList.end(); ++il)
-                            {
-                                if (Creature* Orc = instance->GetCreature(*il))
-                                {
-                                    OrcLocPos.Relocate(OrcLoc[1][0], OrcLoc[1][1], OrcLoc[1][2]);
-                                    Orc->GetRandomPoint(OrcLocPos, 10.0f, x, y, z);
-                                    Orc->SetWalk(false);
-                                    Orc->GetMotionMaster()->MovePoint(0, x, y, z);
-                                }
-                            }
                             (*itr)->SetRespawnTime(1800);
                             (*itr)->UpdateObjectVisibility();
                         }


### PR DESCRIPTION
Some fixes to the start of old hillsbrad:
- Fires will now correctly appear and orcs will run outside once all barrels have been activated. OnObjectCreate was never called because the name was incorrect and thus RoaringFlamesList was always empty.
- Each barrel is now only usable once, previously you could just use one barrel over and over until you hit 5/5. This was because the script was always returning false, which made Spell::SendLoot instantly reset the loot state to GO_JUST_DEACTIVATED (SpellEffects.cpp line 3331).
