### PR TITLE
Removed loot tables of some creatures

### DIFF
--- a/sql/updates/world/2016_04_29_world.sql
+++ b/sql/updates/world/2016_04_29_world.sql
@@ -1,0 +1,11 @@
+-- Remove loot from:
+-- Rotting Worm (10925)
+-- Remorseful Highborne (10684)
+-- Summoned Zombie (10698)
+-- Void Critter (17887)
+-- Flesh Eating Worm (2462)
+-- Succubus Minion (10928)
+-- Spiteful Phantom (10388)
+-- Wrathful Phantom (10389)
+DELETE FROM creature_loot_template WHERE Entry in (10925,10684,10698,17887,2462,10928,10388,10389);
+UPDATE creature_template SET mingold=0,maxgold=0 WHERE Entry in (10925,10684,10698,17887,2462,10928,10388,10389);


### PR DESCRIPTION
Removed loot tables for some creatures that I am fairly sure should not have any loot. I am sure there are more but these are the ones I could find some kind of proof for. Most of these are summoned by some other creature and have loot that is very similar to chests (lots of potions, cloth, ore, food and drink).
- Rotting Worm (10925). These are spawned after killing a Rotting Cadaver (4474) in Western Plaguelands. Current loot table is similar to [this](http://db.hellground.net/?npc=10925) and includes for example a 6.46% chance to drop a 16-slot bag, which is very exploitable since they are so easy to farm. In [this video](https://www.youtube.com/watch?v=L3zm7sWS2I4) at around 1:20, you can clearly see that the worms have no loot, only the zombies.
- Summoned Zombie (10698). These are summoned by Dark Summoner (8551) in Eastern Plaguelands. Loot table looks like [this](http://db.hellground.net/?npc=10698) while [wowhead comments ](http://www.wowhead.com/npc=10698/summoned-zombie#comments) say that there should be no loot.
- Remorseful Highborne (10684). Hostile creature that becomes friendly as a part of a quest. [Wowhead comment](http://www.wowhead.com/npc=10684/remorseful-highborne#comments) states that it has no loot and the [loot table](http://db.hellground.net/?npc=10684) looks out of place.
- Void Critter (17887). Part of quest at Bloodmyst Isle. In [this video](https://www.youtube.com/watch?v=ZMO56xG2yYo) at 3:20 you can see that they have no loot. Currently has 66% chance of dropping HP/Mana potions and food.
- Flesh Eating Worm (2464). Very similar to the Rotting Worm, this one spawns when you kill a Rotted One 948. I have not found any proof of this one not having loot, but judging by the [loot table](http://db.hellground.net/?npc=2462) I have no doubt that it shouldn't.
- Succubus Minion (10928). Summoned by various warlock creatures (creature 1564 for example) and [loot table](http://db.hellground.net/?npc=10928) follows same pattern as the others.
- Spiteful Phantom (10388) and Wrathful Phantom (10389). A curse (16336) placed on players in stratholme will occasionally summon these ghosts to attack you. Their loot tables follows the same patterns as the others here, with one of them having a 7.14% chance to drop a 16-slot bag, so it is very likely that they should not have loot.
