### PR TITLE
Fixed some quest item drop rates

### DIFF
--- a/sql/updates/world/2016_04_30_quest_items.sql
+++ b/sql/updates/world/2016_04_30_quest_items.sql
@@ -1,0 +1,23 @@
+-- Blacksting's Stinger
+update creature_loot_template set chance=100 where entry=18283 and item=25448;
+
+-- Chieftain Mummaki's Totem
+update creature_loot_template set chance=100 where entry=19174 and item=27943;
+
+-- Crystalline Key
+update creature_loot_template set chance=100 where entry=21309 and item=30442;
+
+-- Grillok's Eyepatch
+update creature_loot_template set chance=100 where entry=19457 and item=31529;
+
+-- Orders From Akama
+update creature_loot_template set chance=100 where entry=21663 and item=30649;
+
+-- Raliq's Debt
+update creature_loot_template set chance=100 where entry=18585 and item=25767;
+
+-- Second Fragment of the Cipher of Damnation
+update creature_loot_template set chance=100 where entry=20427 and item=30453;
+
+-- The Final Code
+update creature_loot_template set chance=100 where entry=18554 and item=29912;


### PR DESCRIPTION
Fixed the drop rate of some quest items. These are all items that are dropped from a single unique enemy where you need one copy of the item to complete the quest.
