### PR TITLE
Remove occasional 3 minute delay for creatures on waypoints

### DIFF
--- a/src/game/WaypointMovementGenerator.cpp
+++ b/src/game/WaypointMovementGenerator.cpp
@@ -176,7 +176,7 @@ bool WaypointMovementGenerator<Creature>::Update(Creature& unit, const uint32& d
             if (unit.GetFormation() && unit.GetFormation()->getLeader() == &unit)
                 unit.GetFormation()->LeaderMoveTo(node->x, node->y, node->z);
         }
-        else
+        else if (i_nextMoveTime.Passed()) //don't begin delay until movement is actually finished
         {
             // Determine wait time
             if (node->delay)


### PR DESCRIPTION
There is currently an issue where a creature with waypoint movement will sometimes stay for 3 minutes on the same position. An easy way to see this bug is to go to ramparts and look at [this guy](http://i.imgur.com/Tlkloft.png). He has 3 waypoints and each waypoint has a delay of 2 or 3 seconds. Still, he will often wait for 3 minutes upon arriving to a waypoint.

This fix seems to remove this problem. My guess is that unit.movespline will sometimes not be finalized if i_nextMoveTime is > 0 when a waypoint delay begins, but I have not verified this.
