### PR TITLE
Re-enable evade when leashing

### DIFF
--- a/src/game/HomeMovementGenerator.cpp
+++ b/src/game/HomeMovementGenerator.cpp
@@ -57,7 +57,7 @@ void HomeMovementGenerator<Creature>::_setTargetLocation(Creature& owner)
     init.Launch();
 
     arrived = false;
-    owner.ClearUnitState(UNIT_STATE_ALL_STATE);
+    owner.ClearUnitState(UNIT_STATE_ALL_STATE & ~UNIT_STATE_EVADE);
 }
 
 bool HomeMovementGenerator<Creature>::Update(Creature& owner, const uint32& time_diff)


### PR DESCRIPTION
Currently evading is pretty broken ([example](https://gfycat.com/EnergeticDefensiveJumpingbean)). You can also attack evading units and they will aggro anyone they encounter on the way back to their home position. This is because once the HomeMovementGenerator initializes, the evade state is cleared `owner.ClearUnitState(UNIT_STATE_ALL_STATE);`. This behavior was introduced in [this commit](https://github.com/OregonCore/OregonCore/commit/706e30defc0a324dd835ce29723eadb7cf02be4e) to fix a very annoying issue #880.

I believe the true cause of that issue was fixed (unintentionally?) in [this commit](https://github.com/OregonCore/OregonCore/commit/405aefff2f670d0918a93256f8637488145975ee), more specifically this line `UNIT_STATE_SIGHTLESS       = (UNIT_STATE_LOST_CONTROL | UNIT_STATE_EVADE),`. Before that commit, `MoveInLineOfSight` would be called for units that were evading, which meant they could re-aggro while running back home and get stuck in a permanent evading state. But after that commit the `MoveInLineOfSight` function is not called on evading units.

With this in mind, I think it's a good idea to re-enable evading for units, which this PR does.
