### PR TITLE
Prevent potential permanent evade

### DIFF
--- a/src/game/HomeMovementGenerator.cpp
+++ b/src/game/HomeMovementGenerator.cpp
@@ -30,9 +30,9 @@ void HomeMovementGenerator<Creature>::Initialize(Creature& owner)
 
 void HomeMovementGenerator<Creature>::Finalize(Creature & owner)
 {
+    owner.ClearUnitState(UNIT_STATE_EVADE);
     if (arrived)
     {
-        owner.ClearUnitState(UNIT_STATE_EVADE);
         owner.SetWalk(!owner.HasUnitState(UNIT_STATE_RUNNING_STATE) && !owner.IsLevitating());
         owner.LoadCreaturesAddon(true);
         owner.AI()->JustReachedHome();


### PR DESCRIPTION
Currently, the only way (as far as I can tell) for a unit to be permanently stuck in evade mode is if HomeMovementGenerator gets interrupted before the unit reaches its home position. While this ideally shouldn't happen, there are probably unknown bugs that can cause it to happen. If it does, the unit will most likely be stuck in evade until the server restarts, or until the instance resets if it is inside an instance. With this change, the unit would exit evade state as soon as HomeMovementGenerator is interrupted, even if it had not finished. While this does not actually fix any bug, it is a useful workaround to minimize the impact of other bugs.

Let's say for example that some bug is introduced that makes taunt work on evading units. Currently, the taunted unit would be stuck in evade and follow the caster permanently, but with this change it would atleast clear the evade state the moment it started chasing the caster.
