### PR TITLE
Socrethar's Stone drop now requires quest active

### DIFF
--- a/sql/updates/world/2016_05_06_socrethars_stone.sql
+++ b/sql/updates/world/2016_05_06_socrethars_stone.sql
@@ -1,0 +1,2 @@
+-- First and second half of Socrethar's Stone now requires quest to drop
+UPDATE creature_loot_template SET QuestRequired=1 WHERE Item IN (29624,29625);


### PR DESCRIPTION
The items needed for quest [10508](http://db.hellground.net/?quest=10508) and [10407](http://db.hellground.net/?quest=10407) will no longer drop for players that don't have any of these quests.
