### PR TITLE
Added script to Withered Corpse (20561)

### DIFF
--- a/sql/updates/world/2016_05_07_withered_corpse.sql
+++ b/sql/updates/world/2016_05_07_withered_corpse.sql
@@ -1,0 +1,15 @@
+-- Withered Corpse
+SET @ENTRY := 20561;
+SET @SOURCETYPE := 0;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=@SOURCETYPE;
+UPDATE creature_template SET AIName="SmartAI" WHERE entry=@ENTRY LIMIT 1;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
+(@ENTRY,@SOURCETYPE,1,0,10,0,100,0,0,3,30000,30000,12,20335,4,30000,0,1,0,1,0,0,0,0.0,0.0,0.0,0.0,"Withered Corpse - Summon fleshbeast at 3 yards"),
+(@ENTRY,@SOURCETYPE,2,0,0,0,100,0,0,0,30000,30000,12,20335,4,30000,0,1,0,1,0,0,0,0.0,0.0,0.0,0.0,"Withered Corpse - Summon fleshbeast on enter combat"),
+(@ENTRY,@SOURCETYPE,0,0,17,0,100,0,20335,30000,30000,0,41,0,0,0,0,0,0,1,0,0,0,0.0,0.0,0.0,0.0,"Withered Corpse - Die on summoning fleshbeast");
+
+-- Make attackable
+UPDATE creature_template SET unit_flags=0 WHERE entry=@ENTRY;
+-- Change permanent feign death type from Stun to Root
+UPDATE creature_template_addon SET auras='31261 0' WHERE entry=@ENTRY;

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -2068,7 +2068,8 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
     {
         switch (GetId())
         {
-         case 29266:
+        case 31261:
+        case 29266:
             m_target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_29);
             m_target->SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
             m_target->SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
@@ -2287,6 +2288,7 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                     m_target->ToPlayer()->StopCastingCharm();
                 return;
             }
+        case 31261:
         case 29266:
             {
                 m_target->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_29);


### PR DESCRIPTION
- Will now use aura 31261 (permanent feign death and root) instead of 29266 (permanent feign death and stun) to appear dead. Creatures that are stunned do not receive OOC_LOS events which is needed for this creature. 
- Is now attackable and will summon a Parasitic Fleshbeast (20335) when entering combat. Upon summoning the fleshbeast it will despawn itself. Source videos are [this one](https://www.youtube.com/watch?v=DzswwDQ29uQ) for summoning a fleshbeast and disappearing, and [this one](https://www.youtube.com/watch?v=8mbX-sSzG8k) for being attackable (at around 0:11, you might need to slow down the video but the cursor does turn into an attack symbol on mouse over).
- Will also spawn a fleshbeast and disappear when a player gets close. Can be seen happening at the start of [this video](https://www.youtube.com/watch?v=DzswwDQ29uQ).
- Spell 31261 now also sets feign death flags just like spell 29266.
