### PR TITLE
[WIP][CMake] Cleaned up, Optimize CMake & Upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,16 @@
 
 # Set projectname (must be done AFTER setting configurationtypes)
 project(OregonCore)
+
+# We require cmake >= 2.8
 cmake_minimum_required(VERSION 2.8)
-cmake_policy(VERSION 2.8)
+
+# CMake policies
+cmake_policy(SET CMP0005 OLD)
+cmake_policy(SET CMP0054 OLD)
+if (POLICY CMP0043)
+  cmake_policy(SET CMP0043 OLD)
+endif(POLICY CMP0043)
 
 # Set RPATH-handing (CMake parameters)
 set(CMAKE_SKIP_BUILD_RPATH 0)
@@ -23,12 +31,8 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH 1)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/macros")
 
 # build in preferred mode
-if( NOT CMAKE_BUILD_TYPE )
-    if (WITH_COREDEBUG)
-        set(CMAKE_BUILD_TYPE "Debug")
-    else()
-        set(CMAKE_BUILD_TYPE "Release")
-    endif()
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 include(CheckCXXSourceRuns)
@@ -50,6 +54,7 @@ include(CheckPlatform)
 find_package(PCHSupport)
 find_package(ACE REQUIRED)
 find_package(OpenSSL REQUIRED)
+
 if( NOT USE_MYSQL_SOURCES )
   find_package(MySQL REQUIRED)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 set(sources_Debugging "")
 
+# ToDo: Clean up CMake and opt
 if( SERVERS )
   if (WIN32)
       set(sources_Debugging

--- a/src/collision/CMakeLists.txt
+++ b/src/collision/CMakeLists.txt
@@ -8,6 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+# ToDo: Clean up CMake and opt
 if( USE_COREPCH )
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -8,6 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+# ToDo: Clean up CMake and opt
 SET(oregonframework_STAT_SRCS
    Policies/ObjectLifeTime.cpp
    Utilities/EventProcessor.cpp

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -8,6 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+# ToDo: Clean up CMake and opt
 if (USE_COREPCH)
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/src/oregoncore/CMakeLists.txt
+++ b/src/oregoncore/CMakeLists.txt
@@ -8,6 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+# ToDo: Clean up CMake and opt
 file(GLOB sources_localdir *.cpp *.h)
 
 set(oregon-core_SRCS

--- a/src/oregonrealm/CMakeLists.txt
+++ b/src/oregonrealm/CMakeLists.txt
@@ -8,6 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+# ToDo: Clean up CMake and opt
 file(GLOB sources_localdir *.cpp *.h)
 
 set(oregon-realm_SRCS

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -8,6 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+# ToDo: Clean up CMake and opt
 # Enable precompiled headers when using the GCC compiler.
 if( USE_SCRIPTPCH )
   include_directories(

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -8,6 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+# ToDo: Clean up CMake and opt
 file(GLOB_RECURSE sources_auth Auth/*.cpp Auth/*.h)
 file(GLOB_RECURSE sources_config Config/*.cpp Config/*.h)
 file(GLOB_RECURSE sources_database Database/*.cpp Database/*.h)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -8,6 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+# ToDo: Clean up CMake and opt
 add_subdirectory(movements_extractor)
 add_subdirectory(map_extractor)
 add_subdirectory(vmap_assembler)


### PR DESCRIPTION
# Updating CMake to 3.0
- Uses inherited dependencies & awesome new features as described in [this guide](https://rix0r.nl/blog/2015/08/13/cmake-guide/)!
- Removes some work arounds which target lower CMake Versions
- Automatic inclusion now which makes it easier to add new sources, etc.

**Target Branch**: master

**Issues Addressed**:
- Lot of dependency clutter in whole cmake build files -> proper usage of libraries not utilized.
- Difficult "possible future linking to shared libraries" -> this patch makes it much easier through the
  usage of CMakes internal "BUILD_SHARE_LIBS" option.
- Circular dependency between all areas, the dependency graph is direct acyclic now.

**Upgrades to do**:
- [ ] Upgrade CMake to 3.0 (minimum)
- [ ] Apply required upgrades

**Make sure this stays as a WIP, if merged to early, it will cause issues building**
**Notice: This is a port from my project "FireStorm"**.
