### PR TITLE
Core/Pet: Improve pet follow speed

### DIFF
--- a/src/game/TargetedMovementGenerator.cpp
+++ b/src/game/TargetedMovementGenerator.cpp
@@ -113,7 +113,7 @@ void TargetedMovementGeneratorMedium<T, D>::_setTargetLocation(T& owner, bool up
 
     Movement::MoveSplineInit init(owner);
     init.MovebyPath(i_path->getFullPath());
-    init.SetWalk(((D*)this)->EnableWalking());
+    init.SetWalk(((D*)this)->EnableWalking(owner));
     static_cast<D*>(this)->_updateSpeed(owner);
 
     init.Launch();
@@ -264,15 +264,16 @@ void ChaseMovementGenerator<T>::MovementInform(T& /*unit*/)
 }
 
 template<>
-bool FollowMovementGenerator<Creature>::EnableWalking() const
+bool FollowMovementGenerator<Player>::EnableWalking(Player& /*owner*/) const
 {
-    return i_target.isValid() && i_target->IsWalking();
+    return false;
 }
 
 template<>
-bool FollowMovementGenerator<Player>::EnableWalking() const
+bool FollowMovementGenerator<Creature>::EnableWalking(Creature& owner) const
 {
-    return false;
+    return i_target.isValid() && i_target->IsWalking() &&
+        i_target->GetDistance(owner) < (owner.GetCombatReach() + (sWorld.getRate(RATE_TARGET_POS_RECALCULATION_RANGE) * 2));
 }
 
 template<>

--- a/src/game/TargetedMovementGenerator.cpp
+++ b/src/game/TargetedMovementGenerator.cpp
@@ -96,8 +96,8 @@ void TargetedMovementGeneratorMedium<T, D>::_setTargetLocation(T& owner, bool up
         i_path = new PathInfo(&owner);
 
     // allow pets following their master to cheat while generating paths
-    bool forceDest = (owner.GetTypeId() == TYPEID_UNIT && ((Creature*)&owner)->IsPet()
-        && owner.HasUnitState(UNIT_STATE_FOLLOW));
+    bool forceDest = (owner.GetTypeId() == TYPEID_UNIT && ((Creature*)&owner)->HasUnitTypeMask(UNIT_MASK_MINION) &&
+        owner.HasUnitState(UNIT_STATE_FOLLOW));
 
     bool result = i_path->Update(x, y, z, forceDest);
     if (!result || (i_path->getPathType() & PATHFIND_NOPATH))
@@ -114,6 +114,7 @@ void TargetedMovementGeneratorMedium<T, D>::_setTargetLocation(T& owner, bool up
     Movement::MoveSplineInit init(owner);
     init.MovebyPath(i_path->getFullPath());
     init.SetWalk(((D*)this)->EnableWalking());
+    static_cast<D*>(this)->_updateSpeed(owner);
 
     init.Launch();
 }
@@ -284,12 +285,13 @@ template<>
 void FollowMovementGenerator<Creature>::_updateSpeed(Creature& u)
 {
     // pet only sync speed with owner
-    if (!((Creature&)u).IsPet() || !i_target.isValid() || i_target->GetObjectGUID().GetRawValue() != u.GetOwnerGUID())
+    if (!((Creature&)u).HasUnitTypeMask(UNIT_MASK_MINION) || !i_target.isValid() || i_target->GetGUID() != u.GetCharmerOrOwnerGUID())
         return;
 
     u.UpdateSpeed(MOVE_RUN, true);
     u.UpdateSpeed(MOVE_WALK, true);
     u.UpdateSpeed(MOVE_SWIM, true);
+    u.UpdateSpeed(MOVE_FLIGHT, true);
 }
 
 template<>

--- a/src/game/TargetedMovementGenerator.h
+++ b/src/game/TargetedMovementGenerator.h
@@ -95,7 +95,7 @@ public:
     void Reset(T&);
     void MovementInform(T&);
 
-    bool EnableWalking() const { return false; }
+    bool EnableWalking(T&) const { return false; }
     void _reachTarget(T&);
     void _updateSpeed(T&) {}
 };
@@ -117,7 +117,7 @@ public:
     void Reset(T&);
     void MovementInform(T&);
 
-    bool EnableWalking() const;
+    bool EnableWalking(T&) const;
     void _reachTarget(T&) {}
     void _updateSpeed(T&);
 };

--- a/src/game/TargetedMovementGenerator.h
+++ b/src/game/TargetedMovementGenerator.h
@@ -97,6 +97,7 @@ public:
 
     bool EnableWalking() const { return false; }
     void _reachTarget(T&);
+    void _updateSpeed(T&) {}
 };
 
 template<class T>
@@ -118,9 +119,7 @@ public:
 
     bool EnableWalking() const;
     void _reachTarget(T&) {}
-
-private:
-    void _updateSpeed(T& u);
+    void _updateSpeed(T&);
 };
 
 #endif

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -9382,50 +9382,48 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
 
     switch (mtype)
     {
-        // Only apply debuffs
-        case MOVE_FLIGHT_BACK:
+        case MOVE_WALK:
         case MOVE_RUN_BACK:
         case MOVE_SWIM_BACK:
+        case MOVE_FLIGHT_BACK:
             break;
-        case MOVE_WALK:
-            return;
         case MOVE_RUN:
+        {
+            if (IsMounted()) // Use on mount auras
             {
-                if (IsMounted()) // Use on mount auras
-                {
-                    main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED);
-                    stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS);
-                    non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK)) / 100.0f;
-                }
-                else
-                {
-                    main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_SPEED);
-                    stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_SPEED_ALWAYS);
-                    non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_SPEED_NOT_STACK)) / 100.0f;
-                }
-                break;
+                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_MOUNTED_SPEED);
+                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_MOUNTED_SPEED_ALWAYS);
+                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK)) / 100.0f;
             }
+            else
+            {
+                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_SPEED);
+                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_SPEED_ALWAYS);
+                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_SPEED_NOT_STACK)) / 100.0f;
+            }
+            break;
+        }
         case MOVE_SWIM:
-            {
-                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_SWIM_SPEED);
-                break;
-            }
+        {
+            main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_INCREASE_SWIM_SPEED);
+            break;
+        }
         case MOVE_FLIGHT:
+        {
+            if (IsMounted()) // Use on mount auras
             {
-                if (IsMounted()) // Use on mount auras
-                {
-                    main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED);
-                    stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_STACKING);
-                    non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_NOT_STACKING)) / 100.0f;
-                }
-                else             // Use not mount (shapeshift for example) auras (should stack)
-                {
-                    main_speed_mod  = GetTotalAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED);
-                    stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_FLIGHT_SPEED_STACKING);
-                    non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_NOT_STACKING)) / 100.0f;
-                }
-                break;
+                main_speed_mod  = GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED);
+                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_STACKING);
+                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED_NOT_STACKING)) / 100.0f;
             }
+            else             // Use not mount (shapeshift for example) auras (should stack)
+            {
+                main_speed_mod  = GetTotalAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED);
+                stack_bonus     = GetTotalAuraMultiplier(SPELL_AURA_MOD_FLIGHT_SPEED_STACKING);
+                non_stack_bonus = (100.0f + GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_NOT_STACKING)) / 100.0f;
+            }
+            break;
+        }
         default:
             sLog.outError("Unit::UpdateSpeed: Unsupported move type (%d)", mtype);
             return;
@@ -9441,29 +9439,7 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
         case MOVE_RUN:
         case MOVE_SWIM:
         case MOVE_FLIGHT:
-            {
-            // Set creature speed rate
-            if (GetTypeId() == TYPEID_UNIT)
-            {
-                Unit* pOwner = GetCharmerOrOwner();
-                if ((IsPet() || IsGuardian()) && !IsInCombat() && pOwner) // Must check for owner or crash on "Tame Beast"
-                {
-                    // For every yard over 5, increase speed by 0.01
-                    //  to help prevent pet from lagging behind and despawning
-                    float dist = GetDistance(pOwner);
-                    float base_rate = 1.00f; // base speed is 100% of owner speed
-
-                    if (dist < 5)
-                        dist = 5;
-
-                    float mult = base_rate + ((dist - 5) * 0.01f);
-
-                    speed *= pOwner->GetSpeedRate(mtype) * mult; // pets derive speed from owner when not in combat
-                }
-                else
-                    speed *= ToCreature()->GetCreatureTemplate()->speed_run;    // at this point, MOVE_WALK is never reached
-            }
-
+        {
             // Normalize speed by 191 aura SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED if need
             // @todo possible affect only on MOVE_RUN
             if (int32 normalization = GetMaxPositiveAuraModifier(SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED))
@@ -9486,9 +9462,28 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
             break;
     }
 
-    // for creature case, we check explicit if mob searched for assistance
     if (GetTypeId() == TYPEID_UNIT)
     {
+        if (mtype == MOVE_RUN)
+            speed *= ToCreature()->GetCreatureTemplate()->speed_run;
+
+        if (Unit* owner = GetCharmerOrOwner())
+        {
+            if (ToCreature()->HasUnitTypeMask(UNIT_MASK_MINION) &&
+                ToCreature()->HasUnitState(UNIT_STATE_FOLLOW) && !ToCreature()->IsInCombat())
+            {
+                // Sync speed with owner when near or slower
+                float distance = GetDistance(owner);
+                float owner_speed = owner->GetSpeedRate(mtype);
+                if (distance < (GetCombatReach() + sWorld.getRate(RATE_TARGET_POS_RECALCULATION_RANGE)) || speed < owner_speed)
+                    speed = owner_speed;
+
+                // Increase speed when away to help prevent falling behind
+                speed *= std::min(1.0f + (distance / 100.0f), 1.2f);
+            }
+        }
+
+        // Check if mob searched for assistance
         if (ToCreature()->HasSearchedAssistance())
             speed *= 0.66f;                                 // best guessed value, so this will be 33% reduction. Based off initial speed, mob can then "run", "walk fast" or "walk".
     }


### PR DESCRIPTION
* Fixes pet moving at follow speed when attacking and out of combat
* Fixes pet walking speed
* Fixes pet running animations
Some pets would show as walking when they should be running.
* Caps follow speed bonus
* Fixes follow speed not applying to all pet types
* Pets only sync speed with owner when near or slower
* Fixes follow speed not updating
* Pets only walk when near owner