### PR TITLE
Core/Pet: Fix #1504 - Eyes of the Beast crash

### DIFF
--- a/src/game/Pet.cpp
+++ b/src/game/Pet.cpp
@@ -1455,6 +1455,9 @@ void Pet::_SaveAuras()
                     uint8 i;
                     for (i = 0; i < 3; i++)
                         if (spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_STEALTH ||
+                            spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_CHARM ||
+                            spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_POSSESS ||
+                            spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_POSSESS_PET ||
                             spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AREA_AURA_OWNER ||
                             spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AREA_AURA_PET)
                             break;

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -3293,6 +3293,8 @@ void Aura::HandleModPossessPet(bool apply, bool Real)
     }
     else
     {
+        pet->RemoveCharmedBy(caster);
+
         if (!pet->IsWithinDistInMap(caster, pet->GetMap()->GetVisibilityRange()))
             pet->Remove(PET_SAVE_NOT_IN_SLOT, true);
         else
@@ -3305,12 +3307,10 @@ void Aura::HandleModPossessPet(bool apply, bool Real)
             //  the "follow" flag. Player MUST click "stay" while under the spell.
             if (!pet->GetVictim() && !pet->GetCharmInfo()->HasCommandState(COMMAND_STAY))
             {
-                m_target->GetMotionMaster()->MoveFollow(caster, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
-                m_target->GetCharmInfo()->SetCommandState(COMMAND_FOLLOW);
+                pet->GetMotionMaster()->MoveFollow(caster, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+                pet->GetCharmInfo()->SetCommandState(COMMAND_FOLLOW);
             }
         }
-
-        pet->RemoveCharmedBy(caster);
     }
 }
 

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -12774,7 +12774,8 @@ void Unit::RemoveCharmedBy(Unit* charmer)
     if (ToPlayer())
         ToPlayer()->SetClientControl(this, true);
 
-    DeleteCharmInfo();
+    if (GetTypeId() == TYPEID_PLAYER || (GetTypeId() == TYPEID_UNIT && !IsGuardian()))
+        DeleteCharmInfo();
 
     if (Player* playerCharmer = charmer->ToPlayer())
     {


### PR DESCRIPTION
* Fixes a removed from world crash and others
* Fixes pet is not following player after being possessed
* Fixes pet spells/abilities are removed after being possessed
* Fixes re-logging while channeling Eyes of the Beast
* Closes #1504