### PR TITLE
Updates for mmap script and documentation

### DIFF
--- a/doc/doxygen/InstallationGuide/04_Downloading_and_building_on_Linux.dox
+++ b/doc/doxygen/InstallationGuide/04_Downloading_and_building_on_Linux.dox
@@ -22,18 +22,18 @@ This guide will walk through what tools are needed for building the OregonCore o
 
 To fetch the components for Ubuntu :
 
-    apt-get install build-essential cmake mercurial binutils-dev libiberty-dev libbz2-dev \
+    apt-get install build-essential cmake git binutils-dev libiberty-dev libbz2-dev \
     openssl libssl-dev zlib1g-dev libmysqlclient15-dev libtool mysql-client unrar libace-dev unzip libncurses-dev
 
 To fetch the components for Debian :
 
-    apt-get install g++ gcc make cmake binutils-dev mercurial openssl \
+    apt-get install g++ gcc make cmake binutils-dev git openssl \
     libssl-dev zlib1g-dev libmysqlclient15-dev patch build-essential \
     mysql-client libreadline5-dev libbz2-dev bzip2 libace-dev libbz2-dev
 
 To fetch the components for Fedora/Centos:
 
-    yum install cpp gcc gcc-c++ make cmake mercurial openssl openssl-devel \
+    yum install cpp gcc gcc-c++ make cmake git openssl openssl-devel \
     mysql-devel mysql-server mysql mysql-libs readline readline-devel \
     compat-readline5-devel compat-readline5 zlib-devel binutils-devel ace-devel
 

--- a/src/tools/movements_extractor/Extract/mmap_extract.py
+++ b/src/tools/movements_extractor/Extract/mmap_extract.py
@@ -36,7 +36,7 @@ class workerThread(threading.Thread):
             stInfo.dwFlags |= 0x00000001
             stInfo.wShowWindow = 7
             cFlags = subprocess.CREATE_NEW_CONSOLE
-            binName = "MoveMapGen.exe"
+            binName = "movements_extractor.exe"
         else:
             stInfo = None
             cFlags = 0


### PR DESCRIPTION
1. There was an old name of mmaps extractor .exe file, so I have updated it into new
2. In documentation -> installation on Linux -> required components install commands... we already use git instead of mercurial.. please update also on your doc webpage at http://docs.oregon-core.net/install_lin.html