### PR TITLE
Update 2016_06_17_magetower_portal.sql

### DIFF
--- a/sql/updates/world/2016_06_17_magetower_portal.sql
+++ b/sql/updates/world/2016_06_17_magetower_portal.sql
@@ -1,5 +1,5 @@
 
 -- Proper orientation
-UPDATE `world`.`areatrigger_teleport` SET `target_orientation`=5.16 WHERE  `id`=702;
-UPDATE `world`.`areatrigger_teleport` SET `target_orientation`=5.462 WHERE  `id`=704;
+UPDATE `areatrigger_teleport` SET `target_orientation`=5.16 WHERE  `id`=702;
+UPDATE `areatrigger_teleport` SET `target_orientation`=5.462 WHERE  `id`=704;
 


### PR DESCRIPTION
DB name shouldn't be explicit: this will cause an SQL error (if you use a custom-named DB, e.g. 'test_world') or, worse, it could silently update another DB copy named 'world', which wasn't meant to be updated.