### PR TITLE
Correct Strange Winged Goblin and Wretched Fiend class ID

### DIFF
--- a/sql/updates/world/2017_11_15_00.sql
+++ b/sql/updates/world/2017_11_15_00.sql
@@ -1,0 +1,3 @@
+#Correct unit_class for Strange Winged Goblin and Wretched Fiend
+UPDATE creature_template SET unit_class=1 WHERE entry=22239;
+UPDATE creature_template SET unit_class=2 WHERE entry=24966;


### PR DESCRIPTION
This also removes two console errors shown when starting the core.

Wretched Fiend class ID was taken from retail.
Correct Strange Winged Goblin class ID was compared to other databases.