### PR TITLE
Fix a build error on linux

### DIFF
--- a/src/game/ReputationMgr.h
+++ b/src/game/ReputationMgr.h
@@ -21,6 +21,7 @@
 #include "Common.h"
 #include "SharedDefines.h"
 #include "DBCStructure.h"
+#include "QueryResult.h"
 #include <map>
 
 enum FactionFlags


### PR DESCRIPTION
cc @Zaffy @LordUsagi 

The build is broken on linux:
`In file included from /home/dballa/oregon/OregonCore/src/game/ReputationMgr.cpp:18:0:
/home/dballa/oregon/OregonCore/src/game/ReputationMgr.h:65:21: error: ‘QueryResult_AutoPtr’ has not been declared
     void LoadFromDB(QueryResult_AutoPtr result);`