### PR TITLE
Remove Murgurgula's equipment_id entry

### DIFF
--- a/sql/updates/world/2018_01_30_00_murgurgula_equipment.sql
+++ b/sql/updates/world/2018_01_30_00_murgurgula_equipment.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `equipment_id`=0 WHERE `entry`=17475;


### PR DESCRIPTION
Based on screenshot from 2008 from WoWHead, this NPC does not have any equipment on him.

http://www.wowhead.com/npc=17475/murgurgula#screenshots:id=77743

Also removes one startup error.