### PR TITLE
Fix gamesman hall exit door not opening after win

### DIFF
--- a/src/scripts/EasternKingdoms/Karazhan/chess_event.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/chess_event.cpp
@@ -45,7 +45,7 @@ enum Factions
 };
 
 enum Creatures
-{
+{ismedivh
     NPC_MEDIVH = 16816,
 
     NPC_CHEST_BUNNY = 25213,
@@ -568,8 +568,11 @@ struct Chess_npcAI : public Scripted_NoMovementAI
 
         if (me->GetEntry() == NPC_KING_H || me->GetEntry() == NPC_KING_A)
         {
-            if (IsMedivhControlled(me)) //if medivhs king is killed player won
-                pInstance->SetData(TYPE_CHESS, DONE);
+            if (IsMedivhControlled(me)) {
+				//if medivhs king is killed player won
+				pInstance->SetData(TYPE_CHESS, DONE);
+				pInstance->DoUseDoorOrButton(pInstance->GetData64(DATA_GO_GAME_EXIT_DOOR));
+			}
             else //else player lost
                 pInstance->SetData(TYPE_CHESS, FAIL);
 

--- a/src/scripts/EasternKingdoms/Karazhan/chess_event.cpp
+++ b/src/scripts/EasternKingdoms/Karazhan/chess_event.cpp
@@ -45,7 +45,7 @@ enum Factions
 };
 
 enum Creatures
-{ismedivh
+{
     NPC_MEDIVH = 16816,
 
     NPC_CHEST_BUNNY = 25213,


### PR DESCRIPTION
oops. please remove the {ismedivh part
it was an accident.

only need if 
+(IsMedivhControlled(me)) {
+				//if medivhs king is killed player won
+				pInstance->SetData(TYPE_CHESS, DONE);
+				pInstance->DoUseDoorOrButton(pInstance->GetData64(DATA_GO_GAME_EXIT_DOOR));
+			}